### PR TITLE
Show HN web dashboard UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,34 @@
-import Image from "next/image";
+import { prisma } from "@/lib/prisma";
+import PostsTable from "@/components/PostsTable";
 
-export default function Home() {
+export default async function Home() {
+  const posts = await prisma.showHnPost.findMany({
+    orderBy: { postedAt: "desc" },
+  });
+
+  const serialized = posts.map((p) => ({
+    ...p,
+    postedAt: p.postedAt.toISOString(),
+    createdAt: p.createdAt.toISOString(),
+  }));
+
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+    <div className="min-h-screen bg-white dark:bg-zinc-950">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <header className="mb-10">
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            Show HN Dashboard
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            {posts.length} posts tracked
           </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+        </header>
+        {posts.length === 0 ? (
+          <p className="text-zinc-500 dark:text-zinc-400">No posts yet.</p>
+        ) : (
+          <PostsTable posts={serialized} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/PostsTable.tsx
+++ b/src/components/PostsTable.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+
+type Post = {
+  id: number;
+  hnId: string;
+  title: string;
+  summary: string;
+  url: string;
+  numComments: number;
+  upvotes: number;
+  postedAt: string;
+  createdAt: string;
+};
+
+type SortField = "postedAt" | "upvotes" | "numComments";
+type SortDir = "default" | "asc" | "desc";
+
+function nextDir(dir: SortDir): SortDir {
+  if (dir === "default") return "asc";
+  if (dir === "asc") return "desc";
+  return "default";
+}
+
+function sortIndicator(field: SortField, activeField: SortField, dir: SortDir) {
+  if (field !== activeField || dir === "default") return "";
+  return dir === "asc" ? " ↑" : " ↓";
+}
+
+function groupByDay(posts: Post[]): Map<string, Post[]> {
+  const groups = new Map<string, Post[]>();
+  for (const post of posts) {
+    const day = new Date(post.postedAt).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+    if (!groups.has(day)) groups.set(day, []);
+    groups.get(day)!.push(post);
+  }
+  return groups;
+}
+
+function sortPosts(posts: Post[], field: SortField, dir: SortDir): Post[] {
+  if (dir === "default") {
+    return [...posts].sort(
+      (a, b) => new Date(b.postedAt).getTime() - new Date(a.postedAt).getTime()
+    );
+  }
+  const mult = dir === "asc" ? 1 : -1;
+  return [...posts].sort((a, b) => {
+    if (field === "postedAt") {
+      return mult * (new Date(a.postedAt).getTime() - new Date(b.postedAt).getTime());
+    }
+    return mult * ((a[field] as number) - (b[field] as number));
+  });
+}
+
+function formatTime(dateStr: string) {
+  return new Date(dateStr).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+  });
+}
+
+export default function PostsTable({ posts }: { posts: Post[] }) {
+  const [sortField, setSortField] = useState<SortField>("postedAt");
+  const [sortDir, setSortDir] = useState<SortDir>("default");
+
+  function handleSort(field: SortField) {
+    if (field === sortField) {
+      setSortDir(nextDir(sortDir));
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  }
+
+  const groups = groupByDay(posts);
+
+  return (
+    <div className="space-y-8">
+      {Array.from(groups.entries()).map(([day, dayPosts]) => {
+        const sorted = sortPosts(dayPosts, sortField, sortDir);
+        return (
+          <section key={day}>
+            <div className="flex items-baseline gap-3 mb-3">
+              <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                {day}
+              </h2>
+              <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                {dayPosts.length} post{dayPosts.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+            <div className="overflow-x-auto rounded-lg border border-zinc-200 dark:border-zinc-700">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-zinc-50 dark:bg-zinc-800/50 text-left text-zinc-500 dark:text-zinc-400">
+                    <th className="px-4 py-2.5 font-medium w-[40%]">Title</th>
+                    <th className="px-4 py-2.5 font-medium w-[30%]">Summary</th>
+                    <th
+                      className="px-4 py-2.5 font-medium cursor-pointer select-none whitespace-nowrap hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+                      onClick={() => handleSort("postedAt")}
+                    >
+                      Posted{sortIndicator("postedAt", sortField, sortDir)}
+                    </th>
+                    <th
+                      className="px-4 py-2.5 font-medium cursor-pointer select-none whitespace-nowrap hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors text-right"
+                      onClick={() => handleSort("upvotes")}
+                    >
+                      Upvotes{sortIndicator("upvotes", sortField, sortDir)}
+                    </th>
+                    <th
+                      className="px-4 py-2.5 font-medium cursor-pointer select-none whitespace-nowrap hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors text-right"
+                      onClick={() => handleSort("numComments")}
+                    >
+                      Comments{sortIndicator("numComments", sortField, sortDir)}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                  {sorted.map((post) => (
+                    <tr
+                      key={post.id}
+                      className="hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors"
+                    >
+                      <td className="px-4 py-3">
+                        <a
+                          href={post.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-zinc-900 dark:text-zinc-100 font-medium hover:text-orange-600 dark:hover:text-orange-400 transition-colors"
+                        >
+                          {post.title}
+                        </a>
+                      </td>
+                      <td className="px-4 py-3 text-zinc-600 dark:text-zinc-400 line-clamp-2">
+                        {post.summary}
+                      </td>
+                      <td className="px-4 py-3 text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+                        {formatTime(post.postedAt)}
+                      </td>
+                      <td className="px-4 py-3 text-zinc-500 dark:text-zinc-400 text-right tabular-nums">
+                        {post.upvotes}
+                      </td>
+                      <td className="px-4 py-3 text-zinc-500 dark:text-zinc-400 text-right tabular-nums">
+                        {post.numComments}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- Replace default Next.js home page with a Show HN dashboard that groups posts by day
- Each day section shows date header with post count, and a table with title, summary, posted time, upvotes, and comments
- Client-side sortable columns (posted/upvotes/comments) with toggle cycling through default/asc/desc
- Prisma singleton at `src/lib/prisma.ts` using driver adapter pattern

## Test plan
- [ ] Verify posts load and display grouped by day (most recent first)
- [ ] Click column headers to toggle sort within each day group
- [ ] Verify links open in new tab
- [ ] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)