### PR TITLE
Add db:migrate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start -p 3107",
     "lint": "eslint",
-    "scrape": "npx tsx src/scripts/scrape.ts"
+    "scrape": "npx tsx src/scripts/scrape.ts",
+    "db:migrate": "npx prisma migrate dev"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.7.0",


### PR DESCRIPTION
## Summary
- Adds `db:migrate` script to package.json that runs `npx prisma migrate dev`
- Provides a convenient shorthand for running Prisma migrations during development

## Test plan
- [ ] Run `npm run db:migrate` and verify it invokes Prisma migrate dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)