### PR TITLE
Show top 10 per day with expand toggle

### DIFF
--- a/src/components/PostsTable.tsx
+++ b/src/components/PostsTable.tsx
@@ -69,6 +69,7 @@ function formatTime(dateStr: string) {
 export default function PostsTable({ posts }: { posts: Post[] }) {
   const [sortField, setSortField] = useState<SortField>("postedAt");
   const [sortDir, setSortDir] = useState<SortDir>("default");
+  const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set());
 
   function handleSort(field: SortField) {
     if (field === sortField) {
@@ -85,6 +86,20 @@ export default function PostsTable({ posts }: { posts: Post[] }) {
     <div className="space-y-8">
       {Array.from(groups.entries()).map(([day, dayPosts]) => {
         const sorted = sortPosts(dayPosts, sortField, sortDir);
+        const isExpanded = expandedDays.has(day);
+        const limit = 10;
+        const visiblePosts = isExpanded ? sorted : sorted.slice(0, limit);
+        const hiddenCount = sorted.length - limit;
+
+        function toggleDay() {
+          setExpandedDays((prev) => {
+            const next = new Set(prev);
+            if (next.has(day)) next.delete(day);
+            else next.add(day);
+            return next;
+          });
+        }
+
         return (
           <section key={day}>
             <div className="flex items-baseline gap-3 mb-3">
@@ -122,7 +137,7 @@ export default function PostsTable({ posts }: { posts: Post[] }) {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
-                  {sorted.map((post) => (
+                  {visiblePosts.map((post) => (
                     <tr
                       key={post.id}
                       className="hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors"
@@ -154,6 +169,14 @@ export default function PostsTable({ posts }: { posts: Post[] }) {
                 </tbody>
               </table>
             </div>
+            {hiddenCount > 0 && (
+              <button
+                onClick={toggleDay}
+                className="mt-2 text-sm text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+              >
+                {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
+              </button>
+            )}
           </section>
         );
       })}


### PR DESCRIPTION
## Summary
- Each day group now shows only the top 10 posts by default
- Adds a "Show N more" button below the table when a day has more than 10 posts
- Clicking toggles between expanded (all posts) and collapsed (top 10) views
- Uses `Set<string>` state to track which days are expanded

## Test plan
- [ ] Verify days with <= 10 posts show no toggle button
- [ ] Verify days with > 10 posts show "Show N more" button
- [ ] Click toggle to expand, confirm all posts render
- [ ] Click "Show less" to collapse back to 10
- [ ] Confirm sorting still works correctly with collapsed/expanded state

🤖 Generated with [Claude Code](https://claude.com/claude-code)