### PR TITLE
Month sidebar layout + scrape progress

### DIFF
--- a/src/app/api/scrape/route.ts
+++ b/src/app/api/scrape/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { scrape } from "@/lib/scraper";
+
+let progress = {
+  running: false,
+  total: 0,
+  done: 0,
+  message: "",
+};
+
+export async function GET() {
+  return NextResponse.json(progress);
+}
+
+export async function POST(request: Request) {
+  if (progress.running) {
+    return NextResponse.json({ error: "Scrape already running" }, { status: 409 });
+  }
+
+  const body = await request.json();
+  const days = typeof body.days === "number" ? body.days : 7;
+
+  progress = { running: true, total: 0, done: 0, message: "Starting..." };
+
+  // Run scrape in background (don't await)
+  scrape(days, (done, total, message) => {
+    progress = { running: true, total, done, message };
+  })
+    .then((count) => {
+      progress = { running: false, total: count, done: count, message: `Done. ${count} posts upserted.` };
+    })
+    .catch((err) => {
+      progress = { running: false, total: 0, done: 0, message: `Error: ${err.message}` };
+    });
+
+  return NextResponse.json({ started: true });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import PostsTable from "@/components/PostsTable";
+import Dashboard from "@/components/Dashboard";
 
 export default async function Home() {
   const posts = await prisma.showHnPost.findMany({
@@ -12,23 +12,5 @@ export default async function Home() {
     createdAt: p.createdAt.toISOString(),
   }));
 
-  return (
-    <div className="min-h-screen bg-white dark:bg-zinc-950">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <header className="mb-10">
-          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-            Show HN Dashboard
-          </h1>
-          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-            {posts.length} posts tracked
-          </p>
-        </header>
-        {posts.length === 0 ? (
-          <p className="text-zinc-500 dark:text-zinc-400">No posts yet.</p>
-        ) : (
-          <PostsTable posts={serialized} />
-        )}
-      </div>
-    </div>
-  );
+  return <Dashboard posts={serialized} />;
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import PostsTable from "./PostsTable";
+
+type Post = {
+  id: number;
+  hnId: string;
+  title: string;
+  summary: string;
+  url: string;
+  numComments: number;
+  upvotes: number;
+  postedAt: string;
+  createdAt: string;
+};
+
+type ScrapeProgress = {
+  running: boolean;
+  total: number;
+  done: number;
+  message: string;
+};
+
+function getMonthKey(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function formatMonthLabel(key: string): string {
+  const [year, month] = key.split("-");
+  const d = new Date(Date.UTC(parseInt(year), parseInt(month) - 1, 1));
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    timeZone: "UTC",
+  });
+}
+
+function deriveMonths(posts: Post[]): { key: string; label: string; count: number }[] {
+  const map = new Map<string, number>();
+  for (const p of posts) {
+    const key = getMonthKey(p.postedAt);
+    map.set(key, (map.get(key) || 0) + 1);
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .map(([key, count]) => ({ key, label: formatMonthLabel(key), count }));
+}
+
+export default function Dashboard({ posts }: { posts: Post[] }) {
+  const router = useRouter();
+  const months = deriveMonths(posts);
+  const [selectedMonth, setSelectedMonth] = useState<string>(months[0]?.key ?? "");
+  const [scrapeProgress, setScrapeProgress] = useState<ScrapeProgress | null>(null);
+  const [scrapeDays, setScrapeDays] = useState(7);
+  const [scraping, setScraping] = useState(false);
+
+  const filteredPosts = posts.filter((p) => getMonthKey(p.postedAt) === selectedMonth);
+
+  const pollProgress = useCallback(() => {
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch("/api/scrape");
+        const data: ScrapeProgress = await res.json();
+        setScrapeProgress(data);
+        if (!data.running) {
+          clearInterval(interval);
+          setScraping(false);
+          router.refresh();
+        }
+      } catch {
+        clearInterval(interval);
+        setScraping(false);
+      }
+    }, 2000);
+    return interval;
+  }, [router]);
+
+  async function startScrape() {
+    setScraping(true);
+    setScrapeProgress({ running: true, total: 0, done: 0, message: "Starting..." });
+    try {
+      await fetch("/api/scrape", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ days: scrapeDays }),
+      });
+      pollProgress();
+    } catch {
+      setScraping(false);
+      setScrapeProgress(null);
+    }
+  }
+
+  const pct =
+    scrapeProgress && scrapeProgress.total > 0
+      ? Math.round((scrapeProgress.done / scrapeProgress.total) * 100)
+      : 0;
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-zinc-950">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <header className="mb-10 flex items-center justify-between flex-wrap gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+              Show HN Dashboard
+            </h1>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              {posts.length} posts tracked
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="text-sm text-zinc-500 dark:text-zinc-400">Days:</label>
+            <input
+              type="number"
+              min={1}
+              max={365}
+              value={scrapeDays}
+              onChange={(e) => setScrapeDays(Number(e.target.value))}
+              className="w-16 rounded border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 px-2 py-1 text-sm text-zinc-900 dark:text-zinc-100"
+            />
+            <button
+              onClick={startScrape}
+              disabled={scraping}
+              className="rounded bg-orange-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {scraping ? "Scraping..." : "Scrape"}
+            </button>
+          </div>
+        </header>
+
+        {scraping && scrapeProgress && (
+          <div className="mb-6 rounded-lg border border-zinc-200 dark:border-zinc-700 p-4">
+            <div className="flex items-center justify-between text-sm text-zinc-600 dark:text-zinc-400 mb-2">
+              <span>{scrapeProgress.message}</span>
+              <span>{pct}%</span>
+            </div>
+            <div className="h-2 rounded-full bg-zinc-200 dark:bg-zinc-700 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-orange-500 transition-all duration-300"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-8">
+          {/* Month sidebar */}
+          <aside className="w-[220px] shrink-0">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-3">
+              Months
+            </h2>
+            <nav className="space-y-1">
+              {months.map((m) => (
+                <button
+                  key={m.key}
+                  onClick={() => setSelectedMonth(m.key)}
+                  className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                    m.key === selectedMonth
+                      ? "bg-orange-50 dark:bg-orange-950/30 text-orange-700 dark:text-orange-400 font-medium"
+                      : "text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                  }`}
+                >
+                  <span className="flex items-center justify-between">
+                    <span>{m.label}</span>
+                    <span
+                      className={`text-xs tabular-nums ${
+                        m.key === selectedMonth
+                          ? "text-orange-500 dark:text-orange-500"
+                          : "text-zinc-400 dark:text-zinc-500"
+                      }`}
+                    >
+                      {m.count}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </nav>
+          </aside>
+
+          {/* Main content */}
+          <main className="flex-1 min-w-0">
+            {filteredPosts.length === 0 ? (
+              <p className="text-zinc-500 dark:text-zinc-400">No posts for this month.</p>
+            ) : (
+              <PostsTable posts={filteredPosts} />
+            )}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -1,0 +1,100 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+
+interface HnHit {
+  objectID: string;
+  title: string;
+  url: string | null;
+  points: number;
+  num_comments: number;
+  created_at: string;
+}
+
+interface HnResponse {
+  hits: HnHit[];
+  nbPages: number;
+  hitsPerPage: number;
+  page: number;
+}
+
+function extractSummary(title: string): string {
+  const match = title.match(/^Show HN:\s*(.*)/i);
+  return match ? match[1].trim() : title;
+}
+
+async function fetchPage(page: number, numericFilters: string): Promise<HnResponse> {
+  const url = `http://hn.algolia.com/api/v1/search_by_date?tags=show_hn&hitsPerPage=100&page=${page}&numericFilters=${encodeURIComponent(numericFilters)}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<HnResponse>;
+}
+
+export type ProgressCallback = (done: number, total: number, message: string) => void;
+
+export async function scrape(
+  days: number,
+  onProgress?: ProgressCallback
+): Promise<number> {
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const since = Math.floor(Date.now() / 1000) - days * 86400;
+    const numericFilters = `created_at_i>${since}`;
+
+    // Fetch first page to get total
+    const firstPage = await fetchPage(0, numericFilters);
+    const totalEstimate = firstPage.nbPages * (firstPage.hitsPerPage || 100);
+    let done = 0;
+
+    onProgress?.(0, totalEstimate, `Fetching page 1 of ${firstPage.nbPages}...`);
+
+    async function processHits(hits: HnHit[]) {
+      for (const hit of hits) {
+        const postedAt = new Date(hit.created_at);
+        const hnItemUrl = `https://news.ycombinator.com/item?id=${hit.objectID}`;
+
+        await prisma.showHnPost.upsert({
+          where: { hnId: hit.objectID },
+          update: {
+            title: hit.title,
+            summary: extractSummary(hit.title),
+            url: hit.url || hnItemUrl,
+            numComments: hit.num_comments ?? 0,
+            upvotes: hit.points ?? 0,
+            postedAt,
+          },
+          create: {
+            hnId: hit.objectID,
+            title: hit.title,
+            summary: extractSummary(hit.title),
+            url: hit.url || hnItemUrl,
+            numComments: hit.num_comments ?? 0,
+            upvotes: hit.points ?? 0,
+            postedAt,
+          },
+        });
+
+        done++;
+      }
+    }
+
+    // Process first page
+    await processHits(firstPage.hits);
+    onProgress?.(done, totalEstimate, `Processed page 1 of ${firstPage.nbPages}`);
+
+    // Process remaining pages
+    for (let page = 1; page < firstPage.nbPages; page++) {
+      onProgress?.(done, totalEstimate, `Fetching page ${page + 1} of ${firstPage.nbPages}...`);
+      const data = await fetchPage(page, numericFilters);
+      if (data.hits.length === 0) break;
+      await processHits(data.hits);
+      onProgress?.(done, totalEstimate, `Processed page ${page + 1} of ${firstPage.nbPages}`);
+    }
+
+    onProgress?.(done, done, "Done");
+    return done;
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/scripts/scrape.ts
+++ b/src/scripts/scrape.ts
@@ -2,9 +2,6 @@ import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../generated/prisma/client";
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
-const prisma = new PrismaClient({ adapter });
-
 interface HnHit {
   objectID: string;
   title: string;
@@ -41,6 +38,9 @@ async function fetchPage(page: number, numericFilters: string): Promise<HnRespon
 }
 
 async function main() {
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+  const prisma = new PrismaClient({ adapter });
+
   const days = parseDays();
   const since = Math.floor(Date.now() / 1000) - days * 86400;
   const numericFilters = `created_at_i>${since}`;


### PR DESCRIPTION
## Summary
- Added two-column layout with a fixed-width month sidebar that lists months with post counts, filters the main PostsTable by selected month, and highlights the active month
- Created scrape progress system: extracted scrape logic into `src/lib/scraper.ts`, added API route (`POST` to start, `GET` to poll), and added a progress bar with configurable days input in the Dashboard header
- Updated `page.tsx` to pass all posts to a new `Dashboard` client component that manages month selection and scrape state

## Test plan
- [ ] Verify month sidebar displays all months with correct post counts
- [ ] Verify clicking a month filters the table to only that month's posts
- [ ] Verify the most recent month is selected by default
- [ ] Verify clicking "Scrape" starts a scrape and shows a progress bar
- [ ] Verify progress bar updates every 2 seconds and page refreshes on completion
- [ ] Verify concurrent scrape attempts are rejected (409)

🤖 Generated with [Claude Code](https://claude.com/claude-code)