### PR TITLE
Default sort by upvotes desc

### DIFF
--- a/src/components/PostsTable.tsx
+++ b/src/components/PostsTable.tsx
@@ -67,8 +67,8 @@ function formatTime(dateStr: string) {
 }
 
 export default function PostsTable({ posts }: { posts: Post[] }) {
-  const [sortField, setSortField] = useState<SortField>("postedAt");
-  const [sortDir, setSortDir] = useState<SortDir>("default");
+  const [sortField, setSortField] = useState<SortField>("upvotes");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set());
 
   function handleSort(field: SortField) {


### PR DESCRIPTION
## Summary
- Change default sort from "postedAt" / "default" to "upvotes" / "desc" so posts are ranked by popularity on load

## Test plan
- [ ] Verify posts table loads sorted by upvotes descending by default
- [ ] Verify clicking column headers still cycles sort correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)