### PR TITLE
Fix scraper pagination limit + add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+
+# scrape logs
+scrape.log

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -1,5 +1,14 @@
+import fs from "fs";
+import path from "path";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma/client";
+
+const LOG_FILE = path.resolve(process.cwd(), "scrape.log");
+
+function log(message: string) {
+  const line = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFileSync(LOG_FILE, line);
+}
 
 interface HnHit {
   objectID: string;
@@ -35,65 +44,85 @@ export async function scrape(
   days: number,
   onProgress?: ProgressCallback
 ): Promise<number> {
+  // Clear log file at start of each run
+  fs.writeFileSync(LOG_FILE, "");
+  log(`Starting scrape for ${days} day(s)`);
+
   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
   const prisma = new PrismaClient({ adapter });
 
   try {
-    const since = Math.floor(Date.now() / 1000) - days * 86400;
-    const numericFilters = `created_at_i>${since}`;
+    const now = Math.floor(Date.now() / 1000);
+    let totalUpserted = 0;
 
-    // Fetch first page to get total
-    const firstPage = await fetchPage(0, numericFilters);
-    const totalEstimate = firstPage.nbPages * (firstPage.hitsPerPage || 100);
-    let done = 0;
+    onProgress?.(0, days, "Starting...");
 
-    onProgress?.(0, totalEstimate, `Fetching page 1 of ${firstPage.nbPages}...`);
+    // Iterate from oldest day to newest
+    for (let dayIndex = days - 1; dayIndex >= 0; dayIndex--) {
+      const dayStart = now - (dayIndex + 1) * 86400;
+      const dayEnd = now - dayIndex * 86400;
+      const dayLabel = new Date(dayStart * 1000).toISOString().slice(0, 10);
+      const daysCompleted = days - 1 - dayIndex;
 
-    async function processHits(hits: HnHit[]) {
-      for (const hit of hits) {
-        const postedAt = new Date(hit.created_at);
-        const hnItemUrl = `https://news.ycombinator.com/item?id=${hit.objectID}`;
+      log(`Scraping day ${dayLabel} (${daysCompleted + 1}/${days})`);
+      onProgress?.(daysCompleted, days, `Scraping ${dayLabel}...`);
 
-        await prisma.showHnPost.upsert({
-          where: { hnId: hit.objectID },
-          update: {
-            title: hit.title,
-            summary: extractSummary(hit.title),
-            url: hit.url || hnItemUrl,
-            numComments: hit.num_comments ?? 0,
-            upvotes: hit.points ?? 0,
-            postedAt,
-          },
-          create: {
-            hnId: hit.objectID,
-            title: hit.title,
-            summary: extractSummary(hit.title),
-            url: hit.url || hnItemUrl,
-            numComments: hit.num_comments ?? 0,
-            upvotes: hit.points ?? 0,
-            postedAt,
-          },
-        });
+      const numericFilters = `created_at_i>${dayStart},created_at_i<${dayEnd}`;
+      let page = 0;
+      let dayCount = 0;
 
-        done++;
+      while (true) {
+        log(`  Fetching page ${page + 1} for ${dayLabel}`);
+        let data: HnResponse;
+        try {
+          data = await fetchPage(page, numericFilters);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log(`  Error fetching page ${page + 1} for ${dayLabel}: ${msg}`);
+          throw err;
+        }
+
+        if (data.hits.length === 0) break;
+
+        for (const hit of data.hits) {
+          const postedAt = new Date(hit.created_at);
+          const hnItemUrl = `https://news.ycombinator.com/item?id=${hit.objectID}`;
+
+          await prisma.showHnPost.upsert({
+            where: { hnId: hit.objectID },
+            update: {
+              title: hit.title,
+              summary: extractSummary(hit.title),
+              url: hit.url || hnItemUrl,
+              numComments: hit.num_comments ?? 0,
+              upvotes: hit.points ?? 0,
+              postedAt,
+            },
+            create: {
+              hnId: hit.objectID,
+              title: hit.title,
+              summary: extractSummary(hit.title),
+              url: hit.url || hnItemUrl,
+              numComments: hit.num_comments ?? 0,
+              upvotes: hit.points ?? 0,
+              postedAt,
+            },
+          });
+
+          dayCount++;
+          totalUpserted++;
+        }
+
+        page++;
+        if (page >= data.nbPages) break;
       }
+
+      log(`  ${dayLabel}: ${dayCount} posts (${page} page(s))`);
     }
 
-    // Process first page
-    await processHits(firstPage.hits);
-    onProgress?.(done, totalEstimate, `Processed page 1 of ${firstPage.nbPages}`);
-
-    // Process remaining pages
-    for (let page = 1; page < firstPage.nbPages; page++) {
-      onProgress?.(done, totalEstimate, `Fetching page ${page + 1} of ${firstPage.nbPages}...`);
-      const data = await fetchPage(page, numericFilters);
-      if (data.hits.length === 0) break;
-      await processHits(data.hits);
-      onProgress?.(done, totalEstimate, `Processed page ${page + 1} of ${firstPage.nbPages}`);
-    }
-
-    onProgress?.(done, done, "Done");
-    return done;
+    log(`Scrape complete. Total posts upserted: ${totalUpserted}`);
+    onProgress?.(days, days, `Done. ${totalUpserted} posts upserted.`);
+    return totalUpserted;
   } finally {
     await prisma.$disconnect();
   }

--- a/src/scripts/scrape.ts
+++ b/src/scripts/scrape.ts
@@ -1,6 +1,15 @@
 import "dotenv/config";
+import fs from "fs";
+import path from "path";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../generated/prisma/client";
+
+const LOG_FILE = path.resolve(process.cwd(), "scrape.log");
+
+function log(message: string) {
+  const line = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFileSync(LOG_FILE, line);
+}
 
 interface HnHit {
   objectID: string;
@@ -38,55 +47,73 @@ async function fetchPage(page: number, numericFilters: string): Promise<HnRespon
 }
 
 async function main() {
+  // Clear log file at start
+  fs.writeFileSync(LOG_FILE, "");
+
   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
   const prisma = new PrismaClient({ adapter });
 
   const days = parseDays();
-  const since = Math.floor(Date.now() / 1000) - days * 86400;
-  const numericFilters = `created_at_i>${since}`;
+  const now = Math.floor(Date.now() / 1000);
 
   console.log(`Scraping Show HN posts from the last ${days} day(s)...`);
+  log(`Starting CLI scrape for ${days} day(s)`);
 
-  let page = 0;
   let totalUpserted = 0;
   const dailyCounts: Record<string, number> = {};
 
-  while (true) {
-    const data = await fetchPage(page, numericFilters);
-    if (data.hits.length === 0) break;
+  // Iterate from oldest day to newest
+  for (let dayIndex = days - 1; dayIndex >= 0; dayIndex--) {
+    const dayStart = now - (dayIndex + 1) * 86400;
+    const dayEnd = now - dayIndex * 86400;
+    const dayLabel = new Date(dayStart * 1000).toISOString().slice(0, 10);
 
-    for (const hit of data.hits) {
-      const postedAt = new Date(hit.created_at);
-      const dayKey = postedAt.toISOString().slice(0, 10);
-      const hnItemUrl = `https://news.ycombinator.com/item?id=${hit.objectID}`;
+    log(`Scraping day ${dayLabel}`);
+    console.log(`Scraping ${dayLabel}...`);
 
-      await prisma.showHnPost.upsert({
-        where: { hnId: hit.objectID },
-        update: {
-          title: hit.title,
-          summary: extractSummary(hit.title),
-          url: hit.url || hnItemUrl,
-          numComments: hit.num_comments ?? 0,
-          upvotes: hit.points ?? 0,
-          postedAt,
-        },
-        create: {
-          hnId: hit.objectID,
-          title: hit.title,
-          summary: extractSummary(hit.title),
-          url: hit.url || hnItemUrl,
-          numComments: hit.num_comments ?? 0,
-          upvotes: hit.points ?? 0,
-          postedAt,
-        },
-      });
+    const numericFilters = `created_at_i>${dayStart},created_at_i<${dayEnd}`;
+    let page = 0;
 
-      dailyCounts[dayKey] = (dailyCounts[dayKey] || 0) + 1;
-      totalUpserted++;
+    while (true) {
+      log(`  Fetching page ${page + 1} for ${dayLabel}`);
+      const data = await fetchPage(page, numericFilters);
+      if (data.hits.length === 0) break;
+
+      for (const hit of data.hits) {
+        const postedAt = new Date(hit.created_at);
+        const dayKey = postedAt.toISOString().slice(0, 10);
+        const hnItemUrl = `https://news.ycombinator.com/item?id=${hit.objectID}`;
+
+        await prisma.showHnPost.upsert({
+          where: { hnId: hit.objectID },
+          update: {
+            title: hit.title,
+            summary: extractSummary(hit.title),
+            url: hit.url || hnItemUrl,
+            numComments: hit.num_comments ?? 0,
+            upvotes: hit.points ?? 0,
+            postedAt,
+          },
+          create: {
+            hnId: hit.objectID,
+            title: hit.title,
+            summary: extractSummary(hit.title),
+            url: hit.url || hnItemUrl,
+            numComments: hit.num_comments ?? 0,
+            upvotes: hit.points ?? 0,
+            postedAt,
+          },
+        });
+
+        dailyCounts[dayKey] = (dailyCounts[dayKey] || 0) + 1;
+        totalUpserted++;
+      }
+
+      page++;
+      if (page >= data.nbPages) break;
     }
 
-    page++;
-    if (page >= data.nbPages) break;
+    log(`  ${dayLabel}: ${dailyCounts[dayLabel] || 0} posts`);
   }
 
   console.log(`\nTotal posts upserted: ${totalUpserted}`);
@@ -95,10 +122,12 @@ async function main() {
     console.log(`  ${day}: ${count} posts`);
   }
 
+  log(`Scrape complete. Total: ${totalUpserted}`);
   await prisma.$disconnect();
 }
 
 main().catch((err) => {
+  log(`Fatal error: ${err.message}`);
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- **Time-window pagination**: Break date range into 1-day chunks, querying Algolia per-day with `numericFilters=created_at_i>START,created_at_i<END`. This bypasses the 10-page (1000 hit) API limit since each day typically fits in 1-2 pages.
- **File logging**: Write timestamped logs to `scrape.log` (cleared at each run start) for observability of day-by-day scraping, page fetches, post counts, and errors.
- **Progress callback updated**: Reports day-by-day progress (done/total = days completed/total days) instead of hit-by-hit.

## Test plan
- [ ] Run CLI scrape with `--days 1` and verify posts are fetched
- [ ] Run CLI scrape with `--days 14` and verify all days are covered (check `scrape.log`)
- [ ] Trigger scrape via API route and verify progress polling reflects day-by-day progress
- [ ] Confirm `scrape.log` is created with timestamped entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)