### PR TITLE
Fix month labels + cursor pointer on clickables

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -71,7 +71,7 @@ export default function Dashboard({ posts }: { posts: Post[] }) {
                 <button
                   key={m.key}
                   onClick={() => setSelectedMonth(m.key)}
-                  className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                  className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer ${
                     m.key === selectedMonth
                       ? "bg-orange-50 dark:bg-orange-950/30 text-orange-700 dark:text-orange-400 font-medium"
                       : "text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50"

--- a/src/components/MonthlyChart.tsx
+++ b/src/components/MonthlyChart.tsx
@@ -23,12 +23,12 @@ export default function MonthlyChart({
         {sorted.map((m) => {
           const heightPct = (m.count / max) * 100;
           const isSelected = m.key === selectedMonth;
-          const shortLabel = m.key.slice(2); // "YY-MM"
+          const shortLabel = new Date(m.key + "-01").toLocaleDateString("en-US", { month: "short", year: "2-digit", timeZone: "UTC" });
           return (
             <button
               key={m.key}
               onClick={() => onSelectMonth(m.key)}
-              className="flex-1 flex flex-col items-center justify-end h-full min-w-0 group"
+              className="flex-1 flex flex-col items-center justify-end h-full min-w-0 group cursor-pointer"
               title={`${m.label}: ${m.count} posts`}
             >
               <span className="text-[10px] tabular-nums text-zinc-500 dark:text-zinc-400 mb-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/PostsTable.tsx
+++ b/src/components/PostsTable.tsx
@@ -172,7 +172,7 @@ export default function PostsTable({ posts }: { posts: Post[] }) {
             {hiddenCount > 0 && (
               <button
                 onClick={toggleDay}
-                className="mt-2 text-sm text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+                className="mt-2 text-sm text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
               >
                 {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
               </button>


### PR DESCRIPTION
## Summary
- Fixed month/year label in MonthlyChart bar chart: was showing "YY-MM" format, now shows "MMM YY" (e.g. "Apr 26")
- Added `cursor-pointer` to all clickable elements: chart bar buttons, sidebar month buttons, and expand/collapse toggle buttons

## Test plan
- [ ] Verify chart bar labels display as "MMM YY" format
- [ ] Verify cursor changes to pointer on chart bars, month sidebar buttons, sortable table headers, and expand/collapse buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)