### PR TITLE
fix(day): default sort by upvotes desc

### DIFF
--- a/src/app/day/[date]/page.tsx
+++ b/src/app/day/[date]/page.tsx
@@ -188,7 +188,7 @@ export default async function DayPage({
           </Link>
         </div>
       ) : (
-        <PostsTable posts={serialized} initialRatings={ratings} />
+        <PostsTable posts={serialized} initialRatings={ratings} initialSortField="upvotes" />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Day page (`/day/<date>`) was falling back to `PostsTable`'s default sort field (`aiScore`). This passes `initialSortField="upvotes"` so day pages open sorted by upvotes descending, matching the issue's expected behavior.

## Change
- `src/app/day/[date]/page.tsx` — pass `initialSortField="upvotes"` to `<PostsTable>`. One-line prop addition; component already supports the prop and `sortDir` defaults to `desc`.

## Acceptance check
- [x] `/day/<date>` first paint sorts by upvotes desc
- [x] Upvotes column shows ↓ indicator (rendered by existing `sortIcon` logic in PostsTable)
- [x] Other column headers still re-sort and toggle direction (no behavior change to PostsTable)

## Test plan
- [ ] Visit any populated `/day/<date>` and confirm posts are ordered by upvotes desc
- [ ] Click "Score" / "Comments" headers and confirm re-sort works
- [ ] Click Upvotes header again and confirm direction toggles to asc

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Posts are now sorted by upvotes by default when viewing content by date, making popular content more immediately visible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->