### PR TITLE
feat(search): add advanced filter panel

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,37 +1,122 @@
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import PostsTable from "@/components/PostsTable";
-import SearchBox from "@/components/SearchBox";
+import SearchBox, { type SearchFilters } from "@/components/SearchBox";
+import { Prisma } from "@/generated/prisma/client";
+
+type RawSearchParams = {
+  q?: string;
+  from?: string;
+  to?: string;
+  minUpvotes?: string;
+  minScore?: string;
+  category?: string;
+  sort?: string;
+};
+
+type SortKey = "upvotes" | "newest" | "score";
+const SORT_KEYS: readonly SortKey[] = ["upvotes", "newest", "score"];
+
+function parseInt0(value: string | undefined): number | null {
+  if (!value) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
+}
+
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+function endOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setUTCHours(23, 59, 59, 999);
+  return out;
+}
+
+function buildOrderBy(sort: SortKey): Prisma.ShowHnPostOrderByWithRelationInput[] {
+  if (sort === "newest") return [{ postedAt: "desc" }];
+  if (sort === "score")
+    return [{ aiScore: { sort: "desc", nulls: "last" } }, { upvotes: "desc" }];
+  return [{ upvotes: "desc" }, { postedAt: "desc" }];
+}
+
+const POSTS_TABLE_SORT: Record<SortKey, "upvotes" | "postedAt" | "aiScore"> = {
+  upvotes: "upvotes",
+  newest: "postedAt",
+  score: "aiScore",
+};
 
 export default async function SearchPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string }>;
+  searchParams: Promise<RawSearchParams>;
 }) {
-  const { q } = await searchParams;
-  const query = (q ?? "").trim();
+  const sp = await searchParams;
+  const query = (sp.q ?? "").trim();
+  const from = parseDate(sp.from);
+  const to = parseDate(sp.to);
+  const minUpvotes = parseInt0(sp.minUpvotes);
+  const minScoreRaw = parseInt0(sp.minScore);
+  const minScore = minScoreRaw != null ? Math.min(minScoreRaw, 100) : null;
+  const category = sp.category?.trim() || null;
+  const sort: SortKey = SORT_KEYS.includes(sp.sort as SortKey)
+    ? (sp.sort as SortKey)
+    : "upvotes";
 
-  const posts = query
-    ? await prisma.showHnPost.findMany({
-        where: {
-          OR: [
-            { title: { contains: query, mode: "insensitive" } },
-            { aiSummary: { contains: query, mode: "insensitive" } },
-            { siteDescription: { contains: query, mode: "insensitive" } },
-            { summary: { contains: query, mode: "insensitive" } },
-          ],
-        },
-        orderBy: [{ upvotes: "desc" }, { postedAt: "desc" }],
-        take: 200,
-        include: { rating: { select: { value: true } } },
-      })
-    : [];
+  const hasFilter =
+    query.length > 0 ||
+    from !== null ||
+    to !== null ||
+    minUpvotes !== null ||
+    minScore !== null ||
+    category !== null;
 
-  const ratings = query
-    ? await prisma.userRating.findMany({
-        select: { postId: true, value: true, reason: true },
-      })
-    : [];
+  const where: Prisma.ShowHnPostWhereInput = {};
+  if (query) {
+    where.OR = [
+      { title: { contains: query, mode: "insensitive" } },
+      { aiSummary: { contains: query, mode: "insensitive" } },
+      { siteDescription: { contains: query, mode: "insensitive" } },
+      { summary: { contains: query, mode: "insensitive" } },
+    ];
+  }
+  if (from || to) {
+    where.postedAt = {
+      ...(from ? { gte: from } : {}),
+      ...(to ? { lte: endOfDay(to) } : {}),
+    };
+  }
+  if (minUpvotes != null) where.upvotes = { gte: minUpvotes };
+  if (minScore != null) where.aiScore = { gte: minScore, not: null };
+  if (category) where.category = category;
+
+  const [posts, ratings, categoryRows] = await Promise.all([
+    hasFilter
+      ? prisma.showHnPost.findMany({
+          where,
+          orderBy: buildOrderBy(sort),
+          take: 200,
+          include: { rating: { select: { value: true } } },
+        })
+      : Promise.resolve([]),
+    hasFilter
+      ? prisma.userRating.findMany({
+          select: { postId: true, value: true, reason: true },
+        })
+      : Promise.resolve([]),
+    prisma.showHnPost.findMany({
+      where: { category: { not: null } },
+      distinct: ["category"],
+      select: { category: true },
+      orderBy: { category: "asc" },
+    }),
+  ]);
+
+  const categories = categoryRows
+    .map((r) => r.category)
+    .filter((c): c is string => c !== null);
 
   const serialized = posts.map((p) => {
     const liked = p.rating?.value === 1;
@@ -48,6 +133,27 @@ export default async function SearchPage({
       notable,
     };
   });
+
+  const initialFilters: SearchFilters = {
+    from: sp.from,
+    to: sp.to,
+    minUpvotes: sp.minUpvotes,
+    minScore: sp.minScore,
+    category: category ?? undefined,
+    sort,
+  };
+
+  const extraFiltersActive =
+    from !== null ||
+    to !== null ||
+    minUpvotes !== null ||
+    minScore !== null ||
+    category !== null ||
+    sort !== "upvotes";
+
+  const clearHref = query
+    ? `/search?q=${encodeURIComponent(query)}`
+    : "/search";
 
   return (
     <div className="max-w-[1100px] mx-auto px-6 py-6 md:py-8">
@@ -75,22 +181,41 @@ export default async function SearchPage({
           </div>
         </div>
         <div className="mt-6">
-          <SearchBox initialQuery={query} autoFocus />
+          <SearchBox
+            initialQuery={query}
+            initialFilters={initialFilters}
+            categories={categories}
+            autoFocus
+          />
         </div>
+        {extraFiltersActive && (
+          <div className="mt-3">
+            <Link
+              href={clearHref}
+              className="text-xs font-700 uppercase tracking-widest text-neutral-400 hover:text-neutral-900 transition-colors"
+            >
+              ✕ Clear filters
+            </Link>
+          </div>
+        )}
       </header>
 
-      {!query ? (
+      {!hasFilter ? (
         <div className="text-center py-20 text-neutral-400 text-lg">
-          Type a query to search titles, summaries, and descriptions.
+          Type a query or set a filter to search titles, summaries, and descriptions.
         </div>
       ) : serialized.length === 0 ? (
         <div className="text-center py-20">
           <p className="text-neutral-400 text-lg mb-4">
-            No posts match “{query}”.
+            No posts match your filters.
           </p>
         </div>
       ) : (
-        <PostsTable posts={serialized} initialRatings={ratings} initialSortField="upvotes" />
+        <PostsTable
+          posts={serialized}
+          initialRatings={ratings}
+          initialSortField={POSTS_TABLE_SORT[sort]}
+        />
       )}
     </div>
   );

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -89,7 +89,7 @@ export default async function SearchPage({
     };
   }
   if (minUpvotes != null) where.upvotes = { gte: minUpvotes };
-  if (minScore != null) where.aiScore = { gte: minScore, not: null };
+  if (minScore != null) where.aiScore = { gte: minScore };
   if (category) where.category = category;
 
   const [posts, ratings, categoryRows] = await Promise.all([

--- a/src/components/PostsTable.tsx
+++ b/src/components/PostsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { categoryStyle } from "@/lib/categories";
 
 type AiDetails = {
   targetAudience?: string;
@@ -28,27 +29,6 @@ type Post = {
   category: string | null;
   notable?: boolean;
 };
-
-const CATEGORY_LABELS: Record<string, { label: string; color: string }> = {
-  startup: { label: "Startup", color: "bg-emerald-100 text-emerald-700" },
-  "open-source": { label: "OSS", color: "bg-blue-100 text-blue-700" },
-  "dev-tool": { label: "Dev Tool", color: "bg-indigo-100 text-indigo-700" },
-  "ai-ml": { label: "AI/ML", color: "bg-purple-100 text-purple-700" },
-  "video-game": { label: "Game", color: "bg-pink-100 text-pink-700" },
-  hardware: { label: "Hardware", color: "bg-orange-100 text-orange-700" },
-  educational: { label: "Educational", color: "bg-cyan-100 text-cyan-700" },
-  informational: { label: "Info", color: "bg-teal-100 text-teal-700" },
-  research: { label: "Research", color: "bg-violet-100 text-violet-700" },
-  content: { label: "Content", color: "bg-amber-100 text-amber-700" },
-  demo: { label: "Demo", color: "bg-rose-100 text-rose-700" },
-  hobby: { label: "Hobby", color: "bg-yellow-100 text-yellow-700" },
-  other: { label: "Other", color: "bg-neutral-100 text-neutral-600" },
-};
-
-function categoryStyle(c: string | null) {
-  if (!c) return null;
-  return CATEGORY_LABELS[c] ?? { label: c, color: "bg-neutral-100 text-neutral-600" };
-}
 
 type Rating = { postId: number; value: number; reason: string | null };
 

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,8 +1,55 @@
+"use client";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  startup: "Startup",
+  "open-source": "OSS",
+  "dev-tool": "Dev Tool",
+  "ai-ml": "AI/ML",
+  "video-game": "Game",
+  hardware: "Hardware",
+  educational: "Educational",
+  informational: "Info",
+  research: "Research",
+  content: "Content",
+  demo: "Demo",
+  hobby: "Hobby",
+  other: "Other",
+};
+
+export type SearchFilters = {
+  from?: string;
+  to?: string;
+  minUpvotes?: string;
+  minScore?: string;
+  category?: string;
+  sort?: "upvotes" | "newest" | "score";
+};
+
+const FIELD_CLASS =
+  "px-3 py-2 border-2 border-neutral-200 rounded-xl text-sm font-500 placeholder:text-neutral-400 focus:outline-none focus:border-neutral-900 transition-colors";
+const LABEL_CLASS = "text-[11px] font-700 uppercase tracking-widest text-neutral-500";
+
+function pruneEmpties(form: HTMLFormElement) {
+  for (const el of Array.from(form.elements)) {
+    if (
+      (el instanceof HTMLInputElement || el instanceof HTMLSelectElement) &&
+      el.name &&
+      el.value === ""
+    ) {
+      el.disabled = true;
+    }
+  }
+}
+
 export default function SearchBox({
   initialQuery = "",
+  initialFilters = {},
+  categories = [],
   autoFocus = false,
 }: {
   initialQuery?: string;
+  initialFilters?: SearchFilters;
+  categories?: string[];
   autoFocus?: boolean;
 }) {
   return (
@@ -10,23 +57,111 @@ export default function SearchBox({
       action="/search"
       method="GET"
       role="search"
-      className="flex items-stretch gap-2 w-full"
+      onSubmit={(e) => pruneEmpties(e.currentTarget)}
+      className="flex flex-col gap-3 w-full"
     >
-      <input
-        type="search"
-        name="q"
-        defaultValue={initialQuery}
-        autoFocus={autoFocus}
-        placeholder="Search products by title, summary, or description…"
-        aria-label="Search products"
-        className="flex-1 px-4 py-3 border-2 border-neutral-200 rounded-xl text-base font-500 placeholder:text-neutral-400 focus:outline-none focus:border-neutral-900 transition-colors"
-      />
-      <button
-        type="submit"
-        className="px-5 py-3 border-2 border-neutral-900 bg-neutral-900 text-white rounded-xl text-sm font-700 uppercase tracking-widest hover:bg-white hover:text-neutral-900 transition-colors"
-      >
-        Search
-      </button>
+      <div className="flex items-stretch gap-2 w-full">
+        <input
+          type="search"
+          name="q"
+          defaultValue={initialQuery}
+          autoFocus={autoFocus}
+          placeholder="Search products by title, summary, or description…"
+          aria-label="Search products"
+          className="flex-1 px-4 py-3 border-2 border-neutral-200 rounded-xl text-base font-500 placeholder:text-neutral-400 focus:outline-none focus:border-neutral-900 transition-colors"
+        />
+        <button
+          type="submit"
+          className="px-5 py-3 border-2 border-neutral-900 bg-neutral-900 text-white rounded-xl text-sm font-700 uppercase tracking-widest hover:bg-white hover:text-neutral-900 transition-colors"
+        >
+          Search
+        </button>
+      </div>
+
+      <details open className="group">
+        <summary className="md:hidden cursor-pointer list-none text-xs font-700 uppercase tracking-widest text-neutral-500 hover:text-neutral-900 select-none">
+          <span className="inline-flex items-center gap-2">
+            <span aria-hidden className="group-open:rotate-90 transition-transform inline-block">
+              ›
+            </span>
+            Filters
+          </span>
+        </summary>
+        <div className="grid grid-cols-2 md:grid-cols-6 gap-3 mt-3 md:mt-0">
+          <label className="flex flex-col gap-1">
+            <span className={LABEL_CLASS}>From</span>
+            <input
+              type="date"
+              name="from"
+              defaultValue={initialFilters.from ?? ""}
+              className={FIELD_CLASS}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className={LABEL_CLASS}>To</span>
+            <input
+              type="date"
+              name="to"
+              defaultValue={initialFilters.to ?? ""}
+              className={FIELD_CLASS}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className={LABEL_CLASS}>Min upvotes</span>
+            <input
+              type="number"
+              name="minUpvotes"
+              min={0}
+              step={1}
+              inputMode="numeric"
+              defaultValue={initialFilters.minUpvotes ?? ""}
+              placeholder="0"
+              className={FIELD_CLASS}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className={LABEL_CLASS}>Min score</span>
+            <input
+              type="number"
+              name="minScore"
+              min={0}
+              max={100}
+              step={1}
+              inputMode="numeric"
+              defaultValue={initialFilters.minScore ?? ""}
+              placeholder="0–100"
+              className={FIELD_CLASS}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className={LABEL_CLASS}>Category</span>
+            <select
+              name="category"
+              defaultValue={initialFilters.category ?? ""}
+              className={FIELD_CLASS}
+            >
+              <option value="">Any</option>
+              {categories.map((c) => (
+                <option key={c} value={c}>
+                  {CATEGORY_LABELS[c] ?? c}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className={LABEL_CLASS}>Sort</span>
+            <select
+              name="sort"
+              defaultValue={initialFilters.sort ?? "upvotes"}
+              className={FIELD_CLASS}
+            >
+              <option value="upvotes">Upvotes</option>
+              <option value="newest">Newest</option>
+              <option value="score">Score</option>
+            </select>
+          </label>
+        </div>
+      </details>
     </form>
   );
 }

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,20 +1,6 @@
 "use client";
 
-const CATEGORY_LABELS: Record<string, string> = {
-  startup: "Startup",
-  "open-source": "OSS",
-  "dev-tool": "Dev Tool",
-  "ai-ml": "AI/ML",
-  "video-game": "Game",
-  hardware: "Hardware",
-  educational: "Educational",
-  informational: "Info",
-  research: "Research",
-  content: "Content",
-  demo: "Demo",
-  hobby: "Hobby",
-  other: "Other",
-};
+import { categoryLabel } from "@/lib/categories";
 
 export type SearchFilters = {
   from?: string;
@@ -143,7 +129,7 @@ export default function SearchBox({
               <option value="">Any</option>
               {categories.map((c) => (
                 <option key={c} value={c}>
-                  {CATEGORY_LABELS[c] ?? c}
+                  {categoryLabel(c)}
                 </option>
               ))}
             </select>

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,26 @@
+export const CATEGORY_STYLES: Record<string, { label: string; color: string }> = {
+  startup: { label: "Startup", color: "bg-emerald-100 text-emerald-700" },
+  "open-source": { label: "OSS", color: "bg-blue-100 text-blue-700" },
+  "dev-tool": { label: "Dev Tool", color: "bg-indigo-100 text-indigo-700" },
+  "ai-ml": { label: "AI/ML", color: "bg-purple-100 text-purple-700" },
+  "video-game": { label: "Game", color: "bg-pink-100 text-pink-700" },
+  hardware: { label: "Hardware", color: "bg-orange-100 text-orange-700" },
+  educational: { label: "Educational", color: "bg-cyan-100 text-cyan-700" },
+  informational: { label: "Info", color: "bg-teal-100 text-teal-700" },
+  research: { label: "Research", color: "bg-violet-100 text-violet-700" },
+  content: { label: "Content", color: "bg-amber-100 text-amber-700" },
+  demo: { label: "Demo", color: "bg-rose-100 text-rose-700" },
+  hobby: { label: "Hobby", color: "bg-yellow-100 text-yellow-700" },
+  other: { label: "Other", color: "bg-neutral-100 text-neutral-600" },
+};
+
+const FALLBACK_STYLE = { label: "", color: "bg-neutral-100 text-neutral-600" };
+
+export function categoryStyle(c: string | null) {
+  if (!c) return null;
+  return CATEGORY_STYLES[c] ?? { label: c, color: FALLBACK_STYLE.color };
+}
+
+export function categoryLabel(c: string): string {
+  return CATEGORY_STYLES[c]?.label ?? c;
+}


### PR DESCRIPTION
## Summary

Adds an advanced filter panel to `/search`, composed with the existing free-text query.

- Date range (`from` / `to` on `postedAt`)
- Min upvotes / min AI score
- Category select (distinct values pulled from DB)
- Sort: upvotes / newest / score (whitelisted before reaching Prisma)
- URL-driven state — pure GET form, shareable, back/forward works
- Mobile-collapsible via `<details>` (always-open on `md:` via hidden `<summary>`)
- Server-side filtering through Prisma `where` / `orderBy`
- "Clear filters" link surfaces when any non-`q` filter is active

No new dependencies, no schema changes, reuses existing Tailwind primitives + `PostsTable`.

Code-review pass extracted the shared `CATEGORY_STYLES` map into `src/lib/categories.ts` (was duplicated across `PostsTable` and `SearchBox`).

## Test plan

- [ ] `/search?q=ai` — free-text only, default upvotes-desc sort
- [ ] `/search?q=ai&minUpvotes=50&sort=newest` — combined filter, sort applied
- [ ] `/search?from=2026-04-01&to=2026-04-30&category=startup` — no `q`, filters alone trigger query
- [ ] Submit form with empty fields — URL stays clean (no `&from=&to=&…`)
- [ ] "Clear filters" link returns to `/search?q=<current>`
- [ ] Mobile (<md): filter panel collapses behind "Filters" disclosure
- [ ] Back/forward navigation restores filter state

Closes Planbooq ticket: cmolvyss (ticket id: cmolvyss9000aykntp7bsmyq9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)