### PR TITLE
feat(day): keyboard arrow navigation between days

### DIFF
--- a/src/app/day/[date]/page.tsx
+++ b/src/app/day/[date]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import PostsTable from "@/components/PostsTable";
 import SearchBox from "@/components/SearchBox";
+import DayKeyNav from "@/components/DayKeyNav";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const DOW = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -92,6 +93,7 @@ export default async function DayPage({
 
   return (
     <div className="max-w-[1100px] mx-auto px-6 py-6 md:py-8">
+      <DayKeyNav prevHref={`/day/${prevKey}`} nextHref={nextKey ? `/day/${nextKey}` : null} />
       {/* All days link */}
       <div className="flex items-center gap-6 mb-10">
         <Link

--- a/src/components/DayKeyNav.tsx
+++ b/src/components/DayKeyNav.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+type Props = {
+  prevHref: string;
+  nextHref: string | null;
+};
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+export default function DayKeyNav({ prevHref, nextHref }: Props) {
+  const router = useRouter();
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      if (isEditableTarget(e.target)) return;
+
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        router.push(prevHref);
+        return;
+      }
+      if (nextHref) {
+        e.preventDefault();
+        router.push(nextHref);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [router, prevHref, nextHref]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Adds left/right arrow keyboard navigation on the day view (`/day/[date]`).
- Left → previous day, Right → next day. Disabled at "today" boundary.
- Ignored when focus is on input/textarea/contenteditable, or when any modifier key (cmd/ctrl/alt/shift) is held.
- Uses Next.js client navigation (`router.push`), no full reload.

## Implementation
- New client component `src/components/DayKeyNav.tsx` (returns null, side-effect only).
- Wired into `src/app/day/[date]/page.tsx` with the same `prevKey`/`nextKey` already computed for the on-page arrow links.

## Test plan
- [ ] Visit `/day/<date>`; press ←/→ to navigate.
- [ ] Confirm arrows are ignored while typing in the search box / filter inputs.
- [ ] Confirm modifier-key combos (e.g. cmd+→) are not hijacked.
- [ ] Confirm right arrow is a no-op when on today's page (no next day).

Closes Planbooq ticket: PROD-ERW5TE  (http://localhost:3636)

🤖 Generated with [Claude Code](https://claude.com/claude-code)