### PR TITLE
Add Product Hunt integration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5407/prod_tracker"
+OPENROUTER_API_KEY="your-openrouter-api-key"
+# Optional — enables Product Hunt launch ingestion alongside Show HN.
+# Create a developer token at https://www.producthunt.com/v2/oauth/applications
+PRODUCT_HUNT_TOKEN=""

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A dashboard that tracks and analyzes Show HN posts from Hacker News. Each projec
 ## Features
 
 - Scrapes Show HN posts from the Hacker News Algolia API
+- Optional Product Hunt integration: ingests Product Hunt launches via the Product Hunt API (set `PRODUCT_HUNT_TOKEN`); they are AI-scored and shown alongside Show HN with a source badge
 - AI-powered project analysis via OpenRouter (Gemini 2.5 Flash Lite):
   - Overall interest score (0-100)
   - Target audience identification
@@ -27,7 +28,15 @@ Create a `.env` file:
 ```
 DATABASE_URL="postgresql://postgres:postgres@localhost:5407/prod_tracker"
 OPENROUTER_API_KEY="your-openrouter-api-key"
+
+# Optional — enables Product Hunt launch ingestion alongside Show HN.
+# Create a developer token at https://www.producthunt.com/v2/oauth/applications
+PRODUCT_HUNT_TOKEN="your-product-hunt-developer-token"
 ```
+
+When `PRODUCT_HUNT_TOKEN` is set, the scheduled scrape and `npm run scrape:ph`
+also pull Product Hunt launches into the same dashboard. Without the token,
+Product Hunt ingestion is skipped and only Show HN is tracked.
 
 ### Database
 
@@ -43,6 +52,7 @@ npm run db:migrate
 | `npm run build` | Production build |
 | `npm run scrape` | Scrape last 7 days |
 | `npm run scrape:year` | Scrape last 365 days |
+| `npm run scrape:ph` | Scrape last 7 days of Product Hunt launches (needs `PRODUCT_HUNT_TOKEN`) |
 | `npm run db:migrate` | Run Prisma migrations |
 
 The scraper fetches posts, then reviews unscored posts with AI (10 in parallel). Already-scored posts are skipped on re-runs.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "scrape": "npx tsx src/scripts/scrape.ts",
     "scrape:prod": "npx tsx --env-file=.env.prod src/scripts/scrape.ts",
     "scrape:year": "npx tsx src/scripts/scrape.ts --days 365",
+    "scrape:ph": "npx tsx src/scripts/scrape-ph.ts",
+    "scrape:ph:prod": "npx tsx --env-file=.env.prod src/scripts/scrape-ph.ts",
     "rescore": "npx tsx src/scripts/rescore.ts",
     "rescore:prod": "npx tsx --env-file=.env.prod src/scripts/rescore.ts",
     "db:migrate": "npx prisma migrate dev && npx prisma generate",

--- a/prisma/migrations/20260530170000_add_source/migration.sql
+++ b/prisma/migrations/20260530170000_add_source/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "ShowHnPost" ADD COLUMN "source" TEXT NOT NULL DEFAULT 'show_hn';
+CREATE INDEX "ShowHnPost_source_idx" ON "ShowHnPost"("source");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,7 @@ datasource db {
 model ShowHnPost {
   id             Int      @id @default(autoincrement())
   hnId           String   @unique
+  source         String   @default("show_hn")
   title          String
   summary        String
   url            String
@@ -27,6 +28,7 @@ model ShowHnPost {
   rating         UserRating?
 
   @@index([category])
+  @@index([source])
 }
 
 model UserRating {

--- a/src/components/PostsTable.tsx
+++ b/src/components/PostsTable.tsx
@@ -14,6 +14,7 @@ type AiDetails = {
 type Post = {
   id: number;
   hnId: string;
+  source: string;
   title: string;
   summary: string;
   url: string;
@@ -362,7 +363,10 @@ export default function PostsTable({
               <ul>
                 {sorted.map((post) => {
                   const hostname = getHostname(post.url);
-                  const hnLink = `https://news.ycombinator.com/item?id=${post.hnId}`;
+                  const isPh = post.source === "product_hunt";
+                  const hnLink = isPh
+                    ? post.url
+                    : `https://news.ycombinator.com/item?id=${post.hnId}`;
                   const details = post.aiScoreDetails as AiDetails | null;
                   const det =
                     details && typeof details === "object" && !Array.isArray(details) ? details : null;
@@ -407,6 +411,16 @@ export default function PostsTable({
                         {/* Title + host */}
                         <div className="min-w-0 flex items-baseline gap-2">
                           <span className="text-[10px]">{scoreIcon(post.aiScore)}</span>
+                          <span
+                            title={isPh ? "Product Hunt" : "Hacker News"}
+                            className={`shrink-0 text-[9px] font-800 px-1 rounded leading-none ${
+                              isPh
+                                ? "bg-orange-500/10 text-orange-600"
+                                : "bg-neutral-100 text-neutral-400"
+                            }`}
+                          >
+                            {isPh ? "PH" : "HN"}
+                          </span>
                           {post.notable && (
                             <span
                               title="Notable"

--- a/src/inngest/scheduled-scrape.ts
+++ b/src/inngest/scheduled-scrape.ts
@@ -1,6 +1,7 @@
 import { inngest } from "@/lib/inngest";
 import { prisma } from "@/lib/prisma";
 import { buildDayEntries, scrapeDay } from "@/lib/scraper";
+import { isProductHuntEnabled, scrapePhDay } from "@/lib/producthunt";
 
 const DEFAULT_DAYS = 7;
 const MAX_DAYS = 400;
@@ -30,6 +31,16 @@ export const scheduledScrape = inngest.createFunction(
       total += count;
     }
 
+    let phTotal = 0;
+    if (isProductHuntEnabled()) {
+      for (const entry of entries) {
+        const count = await step.run(`scrape-ph-${entry.dayLabel}`, () =>
+          scrapePhDay(prisma, entry),
+        );
+        phTotal += count;
+      }
+    }
+
     const [unscored, missingPreviews] = await step.run("count-pending", async () => {
       return Promise.all([
         prisma.showHnPost.count({ where: { aiScore: null } }),
@@ -50,6 +61,6 @@ export const scheduledScrape = inngest.createFunction(
       });
     }
 
-    return { days: entries.length, total, unscored, missingPreviews };
+    return { days: entries.length, total, phTotal, unscored, missingPreviews };
   },
 );

--- a/src/lib/producthunt.ts
+++ b/src/lib/producthunt.ts
@@ -1,0 +1,181 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/generated/prisma/client";
+import {
+  buildDayEntries,
+  triggerPostProcessing,
+  type DayEntry,
+  type ProgressCallback,
+} from "./scraper";
+
+const PH_API = "https://api.producthunt.com/v2/api/graphql";
+const PAGE_SIZE = 50;
+
+/** Discriminator stored in ShowHnPost.source for Product Hunt launches. */
+export const PH_SOURCE = "product_hunt";
+
+/** Product Hunt ingest only runs when a developer token is configured. */
+export function isProductHuntEnabled(): boolean {
+  return Boolean(process.env.PRODUCT_HUNT_TOKEN);
+}
+
+interface PhPostNode {
+  id: string;
+  name: string;
+  tagline: string | null;
+  votesCount: number | null;
+  commentsCount: number | null;
+  createdAt: string;
+  featuredAt: string | null;
+  url: string;
+}
+
+interface PhPostsResponse {
+  data?: {
+    posts: {
+      edges: { node: PhPostNode }[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  };
+  errors?: { message: string }[];
+}
+
+const POSTS_QUERY = `
+query Posts($after: String, $postedAfter: DateTime, $postedBefore: DateTime, $first: Int!) {
+  posts(after: $after, postedAfter: $postedAfter, postedBefore: $postedBefore, first: $first) {
+    edges {
+      node {
+        id
+        name
+        tagline
+        votesCount
+        commentsCount
+        createdAt
+        featuredAt
+        url
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}`;
+
+async function phRequest(
+  variables: Record<string, unknown>,
+): Promise<PhPostsResponse> {
+  const token = process.env.PRODUCT_HUNT_TOKEN;
+  if (!token) throw new Error("PRODUCT_HUNT_TOKEN is not set");
+
+  const res = await fetch(PH_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ query: POSTS_QUERY, variables }),
+  });
+  if (!res.ok) throw new Error(`Product Hunt HTTP ${res.status}`);
+
+  const json = (await res.json()) as PhPostsResponse;
+  if (json.errors?.length) {
+    throw new Error(
+      `Product Hunt GraphQL error: ${json.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+  return json;
+}
+
+/** Fetch all Product Hunt launches for a single day, then upsert them. */
+export async function scrapePhDay(
+  prisma: PrismaClient,
+  entry: DayEntry,
+): Promise<number> {
+  const { dayStart, dayEnd, dayLabel } = entry;
+  const postedAfter = new Date(dayStart * 1000).toISOString();
+  const postedBefore = new Date(dayEnd * 1000).toISOString();
+
+  const nodes: PhPostNode[] = [];
+  let after: string | null = null;
+  let pages = 0;
+
+  while (true) {
+    const json = await phRequest({
+      after,
+      postedAfter,
+      postedBefore,
+      first: PAGE_SIZE,
+    });
+    const conn = json.data?.posts;
+    if (!conn) break;
+    nodes.push(...conn.edges.map((e) => e.node));
+    pages++;
+    if (!conn.pageInfo.hasNextPage || !conn.pageInfo.endCursor) break;
+    after = conn.pageInfo.endCursor;
+  }
+
+  for (const node of nodes) {
+    const postedAt = new Date(node.featuredAt || node.createdAt);
+    const data = {
+      title: node.name,
+      summary: node.tagline?.trim() || node.name,
+      url: node.url,
+      numComments: node.commentsCount ?? 0,
+      upvotes: node.votesCount ?? 0,
+      postedAt,
+      source: PH_SOURCE,
+    };
+
+    await prisma.showHnPost.upsert({
+      where: { hnId: `ph_${node.id}` },
+      update: data,
+      create: { hnId: `ph_${node.id}`, ...data },
+    });
+  }
+
+  console.log(`  [PH] ${dayLabel}: ${nodes.length} launches (${pages} page(s))`);
+  return nodes.length;
+}
+
+/** Top-level Product Hunt scrape entry point for the CLI. No-op without a token. */
+export async function scrapeProductHunt(
+  days: number,
+  onProgress?: ProgressCallback,
+): Promise<number> {
+  if (!isProductHuntEnabled()) {
+    console.log("PRODUCT_HUNT_TOKEN not set — skipping Product Hunt ingest.");
+    return 0;
+  }
+
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const entries = buildDayEntries(days);
+    let total = 0;
+    let daysCompleted = 0;
+
+    onProgress?.(0, days, "Starting Product Hunt...");
+
+    for (const entry of entries) {
+      onProgress?.(daysCompleted, days, `Product Hunt: ${entry.dayLabel}...`);
+      console.log(`Scraping Product Hunt: ${entry.dayLabel}...`);
+      total += await scrapePhDay(prisma, entry);
+      daysCompleted++;
+    }
+
+    const { unscored, missingPreviews } = await triggerPostProcessing(prisma);
+    if (unscored > 0) {
+      console.log(`${unscored} unscored posts queued for AI review.`);
+    }
+    if (missingPreviews > 0) {
+      console.log(`${missingPreviews} posts queued for preview fetch.`);
+    }
+
+    onProgress?.(days, days, `Done. ${total} Product Hunt launches upserted.`);
+    return total;
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/scripts/scrape-ph.ts
+++ b/src/scripts/scrape-ph.ts
@@ -1,0 +1,31 @@
+import "dotenv/config";
+import { isProductHuntEnabled, scrapeProductHunt } from "@/lib/producthunt";
+
+function parseDays(): number {
+  const idx = process.argv.indexOf("--days");
+  if (idx !== -1 && process.argv[idx + 1]) {
+    return parseInt(process.argv[idx + 1], 10);
+  }
+  return 7;
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is not set");
+  }
+  if (!isProductHuntEnabled()) {
+    console.log("PRODUCT_HUNT_TOKEN is not set — nothing to do.");
+    return;
+  }
+
+  const days = parseDays();
+  console.log(`Scraping Product Hunt launches from the last ${days} day(s)...`);
+
+  const total = await scrapeProductHunt(days);
+  console.log(`\nTotal Product Hunt posts upserted: ${total}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds Product Hunt as a second launch source feeding the existing ingest → AI-score → preview → display pipeline, so Product Hunt launches are tracked and shown alongside Show HN.

## What changed
- **Schema:** new `source` discriminator on `ShowHnPost` (`show_hn` | `product_hunt`) + index, with a migration.
- **`src/lib/producthunt.ts`:** Product Hunt API v2 (GraphQL) client; day-by-day fetch + upsert mirroring the HN scraper. PH ids are namespaced `ph_<id>` in `hnId`; tagline→summary, votes→upvotes, comments→numComments, featuredAt→postedAt.
- **Ingest wiring:** `scrape:ph` CLI script + folded into the `scheduled-scrape` cron — both token-guarded.
- **UI:** `PostsTable` shows a small `PH`/`HN` source badge and links PH rows to their launch URL.
- **Gating + docs:** all PH behavior is behind `PRODUCT_HUNT_TOKEN` (absent ⇒ no-op, Show HN unchanged); documented in `.env.example` and `README`.

Verified: `tsc --noEmit` and `eslint src` both pass (one pre-existing `<img>` warning, unrelated). Out of scope (no auth/multi-tenant model): user OAuth "connect your account" / managing your own launches — this delivers read-integration.

Closes ticket: PROD-Y3KRBB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Product Hunt integration is now available—displays the latest launches alongside Show HN posts in your feed
  * Posts now include a source badge (HN or PH) with corresponding styling and helpful tooltip
  * New command available to manually trigger Product Hunt data scraping

* **Configuration**
  * New optional `PRODUCT_HUNT_TOKEN` environment variable enables Product Hunt ingestion when configured

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaequery/prod-tracker/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->